### PR TITLE
verdict argument should be an int, not an str

### DIFF
--- a/cli/arguments_builders/search_cli_arguments.py
+++ b/cli/arguments_builders/search_cli_arguments.py
@@ -20,7 +20,7 @@ class SearchCliArguments(DefaultCliArguments):
         self.parser.add_argument('--country', type=str, help='Country (3 digit ISO) e.g. swe')
 
     def add_search_term_verdict_opt(self):
-        self.parser.add_argument('--verdict', type=str, help='Verdict', choices={1: 'whitelisted', 2: 'no verdict', 3: 'no specific threat', 4: 'suspicious', 5: 'malicious'})
+        self.parser.add_argument('--verdict', type=int, help='Verdict', choices={1: 'whitelisted', 2: 'no verdict', 3: 'no specific threat', 4: 'suspicious', 5: 'malicious'})
 
     def add_search_term_av_detect_opt(self):
         def type_av_detect(value):


### PR DESCRIPTION
`verdict` argument wasn't working properly in `search_terms` since it was declared as `str`, while the dictionary keys were `int`s (therefore, Python's argument parser would always compare an `str` to an `int` and think that the passed argument was an invalid choice).